### PR TITLE
feat: 졸업 신청 접수, 제안서, 중간 보고서, 최종 보고서 기능 구현

### DIFF
--- a/src/main/java/com/kyonggi/cspop/controller/FinalController.java
+++ b/src/main/java/com/kyonggi/cspop/controller/FinalController.java
@@ -1,0 +1,48 @@
+package com.kyonggi.cspop.controller;
+
+import com.kyonggi.cspop.controller.dto.graduate.FinalSaveRequest;
+import com.kyonggi.cspop.controller.dto.graduate.MiddleSaveRequest;
+import com.kyonggi.cspop.controller.dto.graduate.RejectRequest;
+import com.kyonggi.cspop.service.dto.graduate.finals.FinalSaveResponseDto;
+import com.kyonggi.cspop.service.dto.graduate.middle.MiddleSaveResponseDto;
+import com.kyonggi.cspop.service.graduate.FinalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/finals")
+public class FinalController {
+
+    private final FinalService finalService;
+
+    @PostMapping("/{studentId}")
+    public ResponseEntity<FinalSaveResponseDto> save(
+            @PathVariable("studentId") Long studentId,
+            @RequestBody @Validated FinalSaveRequest finalSaveRequest
+    ) {
+        FinalSaveResponseDto finalSaveResponseDto = finalService.saveFinal(finalSaveRequest.toServiceDto(), studentId);
+        return ResponseEntity
+                .created(URI.create("/api/proposals/" + finalSaveResponseDto.getId()))
+                .body(finalSaveResponseDto);
+    }
+
+    @PutMapping("/{studentId}/approve")
+    public ResponseEntity<Void> approve(@PathVariable("studentId") Long studentId) {
+        finalService.approveFinal(studentId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{studentId}/reject")
+    public ResponseEntity<Void> reject(
+            @PathVariable("studentId") Long studentId,
+            @RequestBody @Validated RejectRequest rejectRequest
+    ) {
+        finalService.rejectFinal(studentId, rejectRequest.getReason());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/controller/GraduationController.java
+++ b/src/main/java/com/kyonggi/cspop/controller/GraduationController.java
@@ -1,0 +1,38 @@
+package com.kyonggi.cspop.controller;
+
+import com.kyonggi.cspop.controller.auth.AuthenticationPrincipal;
+import com.kyonggi.cspop.controller.dto.graduate.GraduationSaveRequest;
+import com.kyonggi.cspop.controller.dto.student.LoginStudentRequest;
+import com.kyonggi.cspop.service.dto.graduate.GraduationSaveResponseDto;
+import com.kyonggi.cspop.service.graduate.GraduationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/graduates")
+@RequiredArgsConstructor
+public class GraduationController {
+
+    private final GraduationService graduationService;
+
+    @PostMapping
+    public ResponseEntity<GraduationSaveResponseDto> createGraduate(
+            @RequestBody @Validated GraduationSaveRequest graduationSaveRequest,
+            @AuthenticationPrincipal LoginStudentRequest loginStudentRequest
+    ) {
+        GraduationSaveResponseDto graduationSaveResponseDto = graduationService.saveGraduation(
+                graduationSaveRequest.getMethod(),
+                loginStudentRequest.getId()
+        );
+        return ResponseEntity
+                .created(URI.create("/api/graduates/" + graduationSaveResponseDto.getId()))
+                .body(graduationSaveResponseDto);
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/controller/GraduationController.java
+++ b/src/main/java/com/kyonggi/cspop/controller/GraduationController.java
@@ -3,15 +3,14 @@ package com.kyonggi.cspop.controller;
 import com.kyonggi.cspop.controller.auth.AuthenticationPrincipal;
 import com.kyonggi.cspop.controller.dto.graduate.GraduationSaveRequest;
 import com.kyonggi.cspop.controller.dto.student.LoginStudentRequest;
+import com.kyonggi.cspop.service.dto.graduate.GraduationResponseDto;
 import com.kyonggi.cspop.service.dto.graduate.GraduationSaveResponseDto;
+import com.kyonggi.cspop.service.dto.graduate.GraduationsResponseDto;
 import com.kyonggi.cspop.service.graduate.GraduationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -34,5 +33,15 @@ public class GraduationController {
         return ResponseEntity
                 .created(URI.create("/api/graduates/" + graduationSaveResponseDto.getId()))
                 .body(graduationSaveResponseDto);
+    }
+
+    @GetMapping
+    public ResponseEntity<GraduationsResponseDto> findGraduations() {
+        return ResponseEntity.ok(graduationService.findAllGraduation());
+    }
+
+    @GetMapping("/{studentId}")
+    public ResponseEntity<GraduationResponseDto> findGraduation(@PathVariable("studentId") Long studentId) {
+        return ResponseEntity.ok(graduationService.findGraduation(studentId));
     }
 }

--- a/src/main/java/com/kyonggi/cspop/controller/MiddleController.java
+++ b/src/main/java/com/kyonggi/cspop/controller/MiddleController.java
@@ -1,0 +1,46 @@
+package com.kyonggi.cspop.controller;
+
+import com.kyonggi.cspop.controller.dto.graduate.MiddleSaveRequest;
+import com.kyonggi.cspop.controller.dto.graduate.RejectRequest;
+import com.kyonggi.cspop.service.dto.graduate.middle.MiddleSaveResponseDto;
+import com.kyonggi.cspop.service.graduate.MiddleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/middles")
+public class MiddleController {
+
+    private final MiddleService middleService;
+
+    @PostMapping("/{studentId}")
+    public ResponseEntity<MiddleSaveResponseDto> save(
+            @PathVariable("studentId") Long studentId,
+            @RequestBody @Validated MiddleSaveRequest middleSaveRequest
+    ) {
+        MiddleSaveResponseDto middleSaveResponseDto = middleService.saveMiddle(middleSaveRequest.toServiceDto(), studentId);
+        return ResponseEntity
+                .created(URI.create("/api/proposals/" + middleSaveResponseDto.getId()))
+                .body(middleSaveResponseDto);
+    }
+
+    @PutMapping("/{studentId}/approve")
+    public ResponseEntity<Void> approve(@PathVariable("studentId") Long studentId) {
+        middleService.approveMiddle(studentId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{studentId}/reject")
+    public ResponseEntity<Void> reject(
+            @PathVariable("studentId") Long studentId,
+            @RequestBody @Validated RejectRequest rejectRequest
+    ) {
+        middleService.rejectMiddle(studentId, rejectRequest.getReason());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/controller/ProposalController.java
+++ b/src/main/java/com/kyonggi/cspop/controller/ProposalController.java
@@ -1,0 +1,46 @@
+package com.kyonggi.cspop.controller;
+
+import com.kyonggi.cspop.controller.dto.graduate.RejectRequest;
+import com.kyonggi.cspop.controller.dto.graduate.ProposalSaveRequest;
+import com.kyonggi.cspop.service.dto.graduate.proposal.ProposalSaveResponseDto;
+import com.kyonggi.cspop.service.graduate.ProposalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/proposals")
+public class ProposalController {
+
+    private final ProposalService proposalService;
+
+    @PostMapping("/{studentId}")
+    public ResponseEntity<ProposalSaveResponseDto> save(
+            @PathVariable("studentId") Long studentId,
+            @RequestBody @Validated ProposalSaveRequest proposalSaveRequest
+    ) {
+        ProposalSaveResponseDto proposalSaveResponseDto = proposalService.saveProposal(proposalSaveRequest.toServiceDto(), studentId);
+        return ResponseEntity
+                .created(URI.create("/api/proposals/" + proposalSaveResponseDto.getId()))
+                .body(proposalSaveResponseDto);
+    }
+
+    @PutMapping("/{studentId}/approve")
+    public ResponseEntity<Void> approve(@PathVariable("studentId") Long studentId) {
+        proposalService.approveProposal(studentId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{studentId}/reject")
+    public ResponseEntity<Void> reject(
+            @PathVariable("studentId") Long studentId,
+            @RequestBody @Validated RejectRequest rejectRequest
+    ) {
+        proposalService.rejectProposal(studentId, rejectRequest.getReason());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/controller/SubmitController.java
+++ b/src/main/java/com/kyonggi/cspop/controller/SubmitController.java
@@ -1,14 +1,14 @@
 package com.kyonggi.cspop.controller;
 
+import com.kyonggi.cspop.controller.auth.AuthenticationPrincipal;
+import com.kyonggi.cspop.controller.dto.graduate.SubmitUpdateRequest;
 import com.kyonggi.cspop.repository.SubmitRepository;
 import com.kyonggi.cspop.service.dto.graduate.submit.SubmitResponseDto;
 import com.kyonggi.cspop.service.graduate.SubmitService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -26,5 +26,14 @@ public class SubmitController {
         return ResponseEntity
                 .created(URI.create("/api/submits/" + submitResponseDto.getId()))
                 .body(submitResponseDto);
+    }
+
+    @PutMapping("/{studentId}")
+    public ResponseEntity<Void> approve(
+            @RequestBody @Validated SubmitUpdateRequest submitUpdateRequest,
+            @PathVariable("studentId") Long studentId
+    ) {
+        submitService.approveSubmit(submitUpdateRequest.toServiceDto(), studentId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/kyonggi/cspop/controller/SubmitController.java
+++ b/src/main/java/com/kyonggi/cspop/controller/SubmitController.java
@@ -1,0 +1,30 @@
+package com.kyonggi.cspop.controller;
+
+import com.kyonggi.cspop.repository.SubmitRepository;
+import com.kyonggi.cspop.service.dto.graduate.submit.SubmitResponseDto;
+import com.kyonggi.cspop.service.graduate.SubmitService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/submits")
+public class SubmitController {
+
+    private final SubmitService submitService;
+
+    @PostMapping("/{studentId}")
+    public ResponseEntity<SubmitResponseDto> submit(@PathVariable("studentId") Long studentId) {
+        SubmitResponseDto submitResponseDto = submitService.saveSubmit(studentId);
+
+        return ResponseEntity
+                .created(URI.create("/api/submits/" + submitResponseDto.getId()))
+                .body(submitResponseDto);
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/controller/dto/graduate/FinalSaveRequest.java
+++ b/src/main/java/com/kyonggi/cspop/controller/dto/graduate/FinalSaveRequest.java
@@ -1,0 +1,40 @@
+package com.kyonggi.cspop.controller.dto.graduate;
+
+import com.kyonggi.cspop.domain.graduate.Type;
+import com.kyonggi.cspop.service.dto.graduate.finals.FinalSaveRequestDto;
+import com.kyonggi.cspop.service.dto.graduate.proposal.ProposalSaveRequestDto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.kyonggi.cspop.controller.dto.ValidateMessage.EMPTY_MESSAGE;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FinalSaveRequest {
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String title;
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String type;
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String qualification;
+
+    @NotNull(message = EMPTY_MESSAGE)
+    private Integer page;
+
+    public FinalSaveRequestDto toServiceDto() {
+        return new FinalSaveRequestDto(
+                title,
+                Type.from(type),
+                qualification,
+                page
+        );
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/controller/dto/graduate/GraduationSaveRequest.java
+++ b/src/main/java/com/kyonggi/cspop/controller/dto/graduate/GraduationSaveRequest.java
@@ -1,0 +1,18 @@
+package com.kyonggi.cspop.controller.dto.graduate;
+
+import com.kyonggi.cspop.controller.dto.ValidateMessage;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.kyonggi.cspop.controller.dto.ValidateMessage.EMPTY_MESSAGE;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GraduationSaveRequest {
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String method;
+}

--- a/src/main/java/com/kyonggi/cspop/controller/dto/graduate/MiddleSaveRequest.java
+++ b/src/main/java/com/kyonggi/cspop/controller/dto/graduate/MiddleSaveRequest.java
@@ -1,0 +1,39 @@
+package com.kyonggi.cspop.controller.dto.graduate;
+
+import com.kyonggi.cspop.controller.dto.ValidateMessage;
+import com.kyonggi.cspop.domain.graduate.Type;
+import com.kyonggi.cspop.service.dto.graduate.middle.MiddleSaveRequestDto;
+import com.kyonggi.cspop.service.dto.graduate.proposal.ProposalSaveRequestDto;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.kyonggi.cspop.controller.dto.ValidateMessage.EMPTY_MESSAGE;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MiddleSaveRequest {
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String title;
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String type;
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String text;
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String plan;
+
+    public MiddleSaveRequestDto toServiceDto() {
+        return new MiddleSaveRequestDto(
+                title,
+                Type.from(type),
+                text,
+                plan
+        );
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/controller/dto/graduate/ProposalSaveRequest.java
+++ b/src/main/java/com/kyonggi/cspop/controller/dto/graduate/ProposalSaveRequest.java
@@ -1,0 +1,39 @@
+package com.kyonggi.cspop.controller.dto.graduate;
+
+import com.kyonggi.cspop.controller.dto.ValidateMessage;
+import com.kyonggi.cspop.domain.graduate.Type;
+import com.kyonggi.cspop.service.dto.graduate.proposal.ProposalSaveRequestDto;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.kyonggi.cspop.controller.dto.ValidateMessage.EMPTY_MESSAGE;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProposalSaveRequest {
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String title;
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String type;
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String qualification;
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String content;
+
+    public ProposalSaveRequestDto toServiceDto() {
+        return new ProposalSaveRequestDto(
+                title,
+                Type.from(type),
+                qualification,
+                content
+        );
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/controller/dto/graduate/RejectRequest.java
+++ b/src/main/java/com/kyonggi/cspop/controller/dto/graduate/RejectRequest.java
@@ -1,0 +1,17 @@
+package com.kyonggi.cspop.controller.dto.graduate;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.kyonggi.cspop.controller.dto.ValidateMessage.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RejectRequest {
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String reason;
+}

--- a/src/main/java/com/kyonggi/cspop/controller/dto/graduate/SubmitUpdateRequest.java
+++ b/src/main/java/com/kyonggi/cspop/controller/dto/graduate/SubmitUpdateRequest.java
@@ -1,0 +1,35 @@
+package com.kyonggi.cspop.controller.dto.graduate;
+
+import com.kyonggi.cspop.service.dto.graduate.submit.SubmitUpdateRequestDto;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SubmitUpdateRequest {
+
+    @NotNull
+    private LocalDate graduateDate;
+
+    @NotNull
+    private Boolean completion;
+
+    @NotNull
+    private Boolean approve;
+
+    private String reason;
+
+    public SubmitUpdateRequestDto toServiceDto() {
+        return new SubmitUpdateRequestDto(
+                graduateDate,
+                completion,
+                approve,
+                reason
+        );
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Final.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Final.java
@@ -1,0 +1,50 @@
+package com.kyonggi.cspop.domain.graduate;
+
+import com.kyonggi.cspop.domain.BaseEntity;
+import com.kyonggi.cspop.domain.student.Student;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "final_form")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Final extends BaseEntity {
+
+    @Column(name = "final_form_id")
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "approve", nullable = false)
+    private Boolean approve;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "type", nullable = false)
+    private Type type;
+
+    @Column(name = "qualification", nullable = false, length = 45)
+    private String qualification;
+
+    @Column(name = "page", nullable = false)
+    private Integer page;
+
+    @Column(name = "reject_reason", length = 100)
+    private String reason;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "student_id", foreignKey = @ForeignKey(name = "fk_final_student"), nullable = false)
+    private Student student;
+
+    public Final(Boolean approve, String title, Type type, String qualification, Integer page, Student student) {
+        this.approve = approve;
+        this.title = title;
+        this.type = type;
+        this.qualification = qualification;
+        this.page = page;
+        this.student = student;
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Final.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Final.java
@@ -17,13 +17,14 @@ public class Final extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "approve", nullable = false)
+    @Column(name = "approve")
     private Boolean approve;
 
     @Column(name = "title", nullable = false, length = 100)
     private String title;
 
     @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
     private Type type;
 
     @Column(name = "qualification", nullable = false, length = 45)
@@ -39,12 +40,19 @@ public class Final extends BaseEntity {
     @JoinColumn(name = "student_id", foreignKey = @ForeignKey(name = "fk_final_student"), nullable = false)
     private Student student;
 
-    public Final(Boolean approve, String title, Type type, String qualification, Integer page, Student student) {
-        this.approve = approve;
+    public Final(String title, Type type, String qualification, Integer page, Student student) {
         this.title = title;
         this.type = type;
         this.qualification = qualification;
         this.page = page;
         this.student = student;
+    }
+
+    public void changeApprove(Boolean approve) {
+        this.approve = approve;
+    }
+
+    public void changeReason(String reason) {
+        this.reason = reason;
     }
 }

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Graduation.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Graduation.java
@@ -17,6 +17,7 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Graduation extends BaseEntity {
 
+    @Column(name = "graduation_id")
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Graduation.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Graduation.java
@@ -4,12 +4,15 @@ import com.kyonggi.cspop.domain.BaseEntity;
 
 import com.kyonggi.cspop.domain.schedule.Step;
 import com.kyonggi.cspop.domain.student.Student;
+import com.kyonggi.cspop.exception.NotReachedGraduationException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+
+import static java.time.LocalDate.now;
 
 @Entity
 @Getter
@@ -55,6 +58,7 @@ public class Graduation extends BaseEntity {
             String professorName,
             Student student
     ) {
+        validateDate(date);
         this.method = method;
         this.status = status;
         this.step = step;
@@ -64,11 +68,25 @@ public class Graduation extends BaseEntity {
         this.student = student;
     }
 
+    private static void validateDate(LocalDate date) {
+        if (date.isBefore(now())) {
+            throw new NotReachedGraduationException(date.toString());
+        }
+    }
+
     public void changeStatus(Status status) {
         this.status = status;
     }
 
     public void changeStep(Step step) {
         this.step = step;
+    }
+
+    public void changeDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public void changeProfessorName(String professorName) {
+        this.professorName = professorName;
     }
 }

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Graduation.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Graduation.java
@@ -66,6 +66,7 @@ public class Graduation extends BaseEntity {
         this.date = date;
         this.professorName = professorName;
         this.student = student;
+        this.student.addGraduation(this);
     }
 
     private static void validateDate(LocalDate date) {

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Graduation.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Graduation.java
@@ -1,0 +1,73 @@
+package com.kyonggi.cspop.domain.graduate;
+
+import com.kyonggi.cspop.domain.BaseEntity;
+
+import com.kyonggi.cspop.domain.schedule.Step;
+import com.kyonggi.cspop.domain.student.Student;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Table(name = "graduation")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Graduation extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "method")
+    @Enumerated(EnumType.STRING)
+    private Method method;
+
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @Column(name = "step")
+    @Enumerated(EnumType.STRING)
+    private Step step;
+
+    @Column(name = "capstone_completion")
+    private Boolean completion;
+
+    @Column(name = "graduate_date")
+    private LocalDate date;
+
+    @Column(name = "professor_name", length = 10)
+    private String professorName;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "student_id", foreignKey = @ForeignKey(name = "fk_graduation_student"), nullable = false)
+    private Student student;
+
+    public Graduation(
+            Method method,
+            Status status,
+            Step step,
+            Boolean completion,
+            LocalDate date,
+            String professorName,
+            Student student
+    ) {
+        this.method = method;
+        this.status = status;
+        this.step = step;
+        this.completion = completion;
+        this.date = date;
+        this.professorName = professorName;
+        this.student = student;
+    }
+
+    public void changeStatus(Status status) {
+        this.status = status;
+    }
+
+    public void changeStep(Step step) {
+        this.step = step;
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Method.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Method.java
@@ -1,0 +1,23 @@
+package com.kyonggi.cspop.domain.graduate;
+
+import java.util.Arrays;
+
+public enum Method {
+
+    THESIS("논문"),
+    OTHER("기타")
+    ;
+
+    private final String name;
+
+    Method(String name) {
+        this.name = name;
+    }
+
+    public static Method from(String name) {
+        return Arrays.stream(values())
+                .filter(method -> method.name.equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Middle.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Middle.java
@@ -17,7 +17,7 @@ public class Middle extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "approve", nullable = false)
+    @Column(name = "approve")
     private Boolean approve;
 
     @Column(name = "title", nullable = false, length = 100)

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Middle.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Middle.java
@@ -1,0 +1,52 @@
+package com.kyonggi.cspop.domain.graduate;
+
+import com.kyonggi.cspop.domain.BaseEntity;
+import com.kyonggi.cspop.domain.student.Student;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "middle_form")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Middle extends BaseEntity {
+
+    @Column(name = "middle_form_id")
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "approve", nullable = false)
+    private Boolean approve;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "type", nullable = false)
+    private Type type;
+
+    // text
+    @Column(name = "text", nullable = false, length = 500)
+    private String text;
+
+    // plan
+    @Column(name = "plan", nullable = false, length = 500)
+    private String plan;
+
+    @Column(name = "reject_reason", length = 100)
+    private String reason;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "student_id", foreignKey = @ForeignKey(name = "fk_middle_student"), nullable = false)
+    private Student student;
+
+    public Middle(Boolean approve, String title, Type type, String text, String plan, Student student) {
+        this.approve = approve;
+        this.title = title;
+        this.type = type;
+        this.text = text;
+        this.plan = plan;
+        this.student = student;
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Middle.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Middle.java
@@ -24,13 +24,12 @@ public class Middle extends BaseEntity {
     private String title;
 
     @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
     private Type type;
 
-    // text
     @Column(name = "text", nullable = false, length = 500)
     private String text;
 
-    // plan
     @Column(name = "plan", nullable = false, length = 500)
     private String plan;
 
@@ -41,12 +40,19 @@ public class Middle extends BaseEntity {
     @JoinColumn(name = "student_id", foreignKey = @ForeignKey(name = "fk_middle_student"), nullable = false)
     private Student student;
 
-    public Middle(Boolean approve, String title, Type type, String text, String plan, Student student) {
-        this.approve = approve;
+    public Middle(String title, Type type, String text, String plan, Student student) {
         this.title = title;
         this.type = type;
         this.text = text;
         this.plan = plan;
         this.student = student;
+    }
+
+    public void changeApprove(Boolean approve) {
+        this.approve = approve;
+    }
+
+    public void changeReason(String reason) {
+        this.reason = reason;
     }
 }

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Proposal.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Proposal.java
@@ -17,13 +17,14 @@ public class Proposal extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "approve", nullable = false)
+    @Column(name = "approve")
     private Boolean approve;
 
     @Column(name = "title", nullable = false, length = 100)
     private String title;
 
     @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
     private Type type;
 
     @Column(name = "qualification", nullable = false, length = 45)
@@ -39,12 +40,19 @@ public class Proposal extends BaseEntity {
     @JoinColumn(name = "student_id", foreignKey = @ForeignKey(name = "fk_proposal_student"), nullable = false)
     private Student student;
 
-    public Proposal(Boolean approve, String title, Type type, String qualification, String content, Student student) {
-        this.approve = approve;
+    public Proposal(String title, Type type, String qualification, String content, Student student) {
         this.title = title;
         this.type = type;
         this.qualification = qualification;
         this.content = content;
         this.student = student;
+    }
+
+    public void changeApprove(Boolean approve) {
+        this.approve = approve;
+    }
+
+    public void changeReason(String reason) {
+        this.reason = reason;
     }
 }

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Proposal.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Proposal.java
@@ -1,0 +1,50 @@
+package com.kyonggi.cspop.domain.graduate;
+
+import com.kyonggi.cspop.domain.BaseEntity;
+import com.kyonggi.cspop.domain.student.Student;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "proposal")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Proposal extends BaseEntity {
+
+    @Column(name = "proposal_id")
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "approve", nullable = false)
+    private Boolean approve;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "type", nullable = false)
+    private Type type;
+
+    @Column(name = "qualification", nullable = false, length = 45)
+    private String qualification;
+
+    @Column(name = "content", nullable = false, length = 45)
+    private String content;
+
+    @Column(name = "reject_reason", length = 100)
+    private String reason;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "student_id", foreignKey = @ForeignKey(name = "fk_proposal_student"), nullable = false)
+    private Student student;
+
+    public Proposal(Boolean approve, String title, Type type, String qualification, String content, Student student) {
+        this.approve = approve;
+        this.title = title;
+        this.type = type;
+        this.qualification = qualification;
+        this.content = content;
+        this.student = student;
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Status.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Status.java
@@ -1,0 +1,23 @@
+package com.kyonggi.cspop.domain.graduate;
+
+import java.util.Arrays;
+
+public enum Status {
+
+    APPROVAL("승인"),
+    UN_APPROVAL("미승인"),
+    REJECT("반려");
+
+    private final String name;
+
+    Status(String name) {
+        this.name = name;
+    }
+
+    public static Status from(String name) {
+        return Arrays.stream(values())
+                .filter(status -> status.name.equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Submit.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Submit.java
@@ -1,6 +1,7 @@
 package com.kyonggi.cspop.domain.graduate;
 
 import com.kyonggi.cspop.domain.BaseEntity;
+import com.kyonggi.cspop.domain.student.Student;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,9 +21,9 @@ public class Submit extends BaseEntity {
     private Long id;
 
     @Column(name = "professor_name", nullable = false, length = 10)
-    private String Name;
+    private String name;
 
-    @Column(name = "graduate_date", nullable = false)
+    @Column(name = "graduate_date")
     private LocalDate graduateDate;
 
     @Column(name = "capstone_completion")
@@ -34,10 +35,28 @@ public class Submit extends BaseEntity {
     @Column(name = "reject_reason", length = 100)
     private String reason;
 
-    public Submit(String name, LocalDate graduateDate, Boolean completion, Boolean approve) {
-        Name = name;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "student_id", foreignKey = @ForeignKey(name = "fk_final_student"), nullable = false)
+    private Student student;
+
+    public Submit(String name, Student student) {
+        this.name = name;
+        this.student = student;
+    }
+
+    public void changeGraduateDate(LocalDate graduateDate) {
         this.graduateDate = graduateDate;
-        this.completion = completion;
+    }
+
+    public void changeApprove(Boolean approve) {
         this.approve = approve;
+    }
+
+    public void changeCompletion(Boolean completion) {
+        this.completion = completion;
+    }
+
+    public void changeReason(String reason) {
+        this.reason = reason;
     }
 }

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Submit.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Submit.java
@@ -29,7 +29,7 @@ public class Submit extends BaseEntity {
     @Column(name = "capstone_completion")
     private Boolean completion;
 
-    @Column(name = "approve", nullable = false)
+    @Column(name = "approve")
     private Boolean approve;
 
     @Column(name = "reject_reason", length = 100)

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Submit.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Submit.java
@@ -36,7 +36,7 @@ public class Submit extends BaseEntity {
     private String reason;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "student_id", foreignKey = @ForeignKey(name = "fk_final_student"), nullable = false)
+    @JoinColumn(name = "student_id", foreignKey = @ForeignKey(name = "fk_submit_student"), nullable = false)
     private Student student;
 
     public Submit(String name, Student student) {

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Submit.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Submit.java
@@ -1,0 +1,43 @@
+package com.kyonggi.cspop.domain.graduate;
+
+import com.kyonggi.cspop.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@Table(name = "submit")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Submit extends BaseEntity {
+
+    @Column(name = "submit_id")
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "professor_name", nullable = false, length = 10)
+    private String Name;
+
+    @Column(name = "graduate_date", nullable = false)
+    private LocalDate graduateDate;
+
+    @Column(name = "capstone_completion")
+    private Boolean completion;
+
+    @Column(name = "approve", nullable = false)
+    private Boolean approve;
+
+    @Column(name = "reject_reason", length = 100)
+    private String reason;
+
+    public Submit(String name, LocalDate graduateDate, Boolean completion, Boolean approve) {
+        Name = name;
+        this.graduateDate = graduateDate;
+        this.completion = completion;
+        this.approve = approve;
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/domain/graduate/Type.java
+++ b/src/main/java/com/kyonggi/cspop/domain/graduate/Type.java
@@ -1,0 +1,23 @@
+package com.kyonggi.cspop.domain.graduate;
+
+import java.util.Arrays;
+
+public enum Type {
+
+    IMPLEMENT("구현"),
+    INVESTIGATE("조사")
+    ;
+
+    private final String name;
+
+    Type(String name) {
+        this.name = name;
+    }
+
+    public static Type from(String name) {
+        return Arrays.stream(values())
+                .filter(type -> type.name.equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/domain/student/Student.java
+++ b/src/main/java/com/kyonggi/cspop/domain/student/Student.java
@@ -145,4 +145,8 @@ public class Student extends BaseEntity {
     public boolean isSame(Long id) {
         return this.id.equals(id);
     }
+
+    public void addGraduation(Graduation graduation) {
+        this.graduation = graduation;
+    }
 }

--- a/src/main/java/com/kyonggi/cspop/domain/student/Student.java
+++ b/src/main/java/com/kyonggi/cspop/domain/student/Student.java
@@ -1,6 +1,9 @@
 package com.kyonggi.cspop.domain.student;
 
 import com.kyonggi.cspop.domain.BaseEntity;
+import com.kyonggi.cspop.domain.graduate.Graduation;
+import com.kyonggi.cspop.domain.graduate.Status;
+import com.kyonggi.cspop.domain.schedule.Step;
 import com.kyonggi.cspop.exception.NotReachedBirthException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -15,7 +18,6 @@ import static com.kyonggi.cspop.domain.student.RoleType.STUDENT;
 @Getter
 @Entity
 @Table(name = "student")
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Student extends BaseEntity {
 
@@ -60,6 +62,9 @@ public class Student extends BaseEntity {
     @Column(name = "roleType", nullable = false, length = 10)
     private RoleType roleType;
 
+    @OneToOne(mappedBy = "student")
+    private Graduation graduation;
+
     public Student(
             String number,
             String loginId,
@@ -86,10 +91,51 @@ public class Student extends BaseEntity {
         this.roleType = STUDENT;
     }
 
+    public Student(
+            Long id,
+            String number,
+            String loginId,
+            String password,
+            LocalDate birth,
+            Department department,
+            Grade grade,
+            PhoneNumber phoneNumber,
+            String name,
+            Email email,
+            Classification classification,
+            RoleType roleType
+    ) {
+        this.id = id;
+        this.number = number;
+        this.loginId = loginId;
+        this.password = password;
+        this.birth = birth;
+        this.department = department;
+        this.grade = grade;
+        this.phoneNumber = phoneNumber;
+        this.name = name;
+        this.email = email;
+        this.classification = classification;
+        this.roleType = roleType;
+    }
+
     private static void validateLimitBirthDate(LocalDate birth) {
         if (isNotReached(birth)) {
             throw new NotReachedBirthException(birth.toString());
         }
+    }
+
+    public void changeGraduationStatus(Status status) {
+        this.graduation.changeStatus(status);
+    }
+
+    public void changeGraduationStep(Step step) {
+        this.graduation.changeStep(step);
+    }
+
+    public void changeGraduationSubmit(LocalDate date, String professorName) {
+        this.graduation.changeDate(date);
+        this.graduation.changeProfessorName(professorName);
     }
 
     private static boolean isNotReached(LocalDate birth) {

--- a/src/main/java/com/kyonggi/cspop/exception/NoSuchFinalException.java
+++ b/src/main/java/com/kyonggi/cspop/exception/NoSuchFinalException.java
@@ -1,0 +1,15 @@
+package com.kyonggi.cspop.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NoSuchFinalException extends CspopException {
+
+    public NoSuchFinalException(Long id) {
+        super(
+                String.format("최종보고서 제출을 하지 않은 학생입니다. id = {%d}", id),
+                "최종보고서 제출을 하지 않은 학생입니다.",
+                HttpStatus.NOT_FOUND,
+                "4025"
+        );
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/exception/NoSuchGraduationException.java
+++ b/src/main/java/com/kyonggi/cspop/exception/NoSuchGraduationException.java
@@ -1,0 +1,14 @@
+package com.kyonggi.cspop.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NoSuchGraduationException extends CspopException {
+    public NoSuchGraduationException(Long id) {
+        super(
+                String.format("졸업을 신청하지 않은 학생입니다. id = {%d}", id),
+                "졸업을 신청하지 않은 학생입니다.",
+                HttpStatus.NOT_FOUND,
+                "4021"
+        );
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/exception/NoSuchMiddleException.java
+++ b/src/main/java/com/kyonggi/cspop/exception/NoSuchMiddleException.java
@@ -1,0 +1,15 @@
+package com.kyonggi.cspop.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NoSuchMiddleException extends CspopException {
+
+    public NoSuchMiddleException(Long id) {
+        super(
+                String.format("중간보고서 제출을 하지 않은 학생입니다. id = {%d}", id),
+                "중간보고서 제출을 하지 않은 학생입니다.",
+                HttpStatus.NOT_FOUND,
+                "4024"
+        );
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/exception/NoSuchProposalException.java
+++ b/src/main/java/com/kyonggi/cspop/exception/NoSuchProposalException.java
@@ -1,0 +1,15 @@
+package com.kyonggi.cspop.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NoSuchProposalException extends CspopException {
+
+    public NoSuchProposalException(Long id) {
+        super(
+                String.format("제안서 제출을 하지 않은 학생입니다. id = {%d}", id),
+                "제안서 제출을 하지 않은 학생입니다.",
+                HttpStatus.NOT_FOUND,
+                "4023"
+        );
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/exception/NoSuchSubmitException.java
+++ b/src/main/java/com/kyonggi/cspop/exception/NoSuchSubmitException.java
@@ -1,0 +1,15 @@
+package com.kyonggi.cspop.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NoSuchSubmitException extends CspopException {
+
+    public NoSuchSubmitException(Long id) {
+        super(
+                String.format("접수를 하지 않은 학생입니다. id = {%d}", id),
+                "접수를 하지 않은 학생입니다.",
+                HttpStatus.NOT_FOUND,
+                "4022"
+        );
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/exception/NotReachedGraduationException.java
+++ b/src/main/java/com/kyonggi/cspop/exception/NotReachedGraduationException.java
@@ -1,0 +1,15 @@
+package com.kyonggi.cspop.exception;
+
+import org.springframework.http.HttpStatus;
+
+
+public class NotReachedGraduationException extends CspopException {
+    public NotReachedGraduationException(String birth) {
+        super(
+                String.format("졸업 날짜는 현재 시점보다 빠를 수 없습니다. 졸업날짜 = {%s}", birth),
+                "졸업 날짜는 현재 시점보다 빠를 수 없습니다.",
+                HttpStatus.BAD_REQUEST,
+                "4026"
+        );
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/repository/FinalRepository.java
+++ b/src/main/java/com/kyonggi/cspop/repository/FinalRepository.java
@@ -1,0 +1,13 @@
+package com.kyonggi.cspop.repository;
+
+import com.kyonggi.cspop.domain.graduate.Final;
+import com.kyonggi.cspop.domain.graduate.Submit;
+import com.kyonggi.cspop.domain.student.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FinalRepository extends JpaRepository<Final, Long> {
+
+    Optional<Final> findByStudent(Student student);
+}

--- a/src/main/java/com/kyonggi/cspop/repository/GraduationRepository.java
+++ b/src/main/java/com/kyonggi/cspop/repository/GraduationRepository.java
@@ -1,7 +1,12 @@
 package com.kyonggi.cspop.repository;
 
 import com.kyonggi.cspop.domain.graduate.Graduation;
+import com.kyonggi.cspop.domain.student.Student;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GraduationRepository extends JpaRepository<Graduation, Long> {
+
+    Optional<Graduation> findByStudent(Student student);
 }

--- a/src/main/java/com/kyonggi/cspop/repository/GraduationRepository.java
+++ b/src/main/java/com/kyonggi/cspop/repository/GraduationRepository.java
@@ -1,0 +1,7 @@
+package com.kyonggi.cspop.repository;
+
+import com.kyonggi.cspop.domain.graduate.Graduation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GraduationRepository extends JpaRepository<Graduation, Long> {
+}

--- a/src/main/java/com/kyonggi/cspop/repository/MiddleRepository.java
+++ b/src/main/java/com/kyonggi/cspop/repository/MiddleRepository.java
@@ -1,0 +1,13 @@
+package com.kyonggi.cspop.repository;
+
+import com.kyonggi.cspop.domain.graduate.Middle;
+import com.kyonggi.cspop.domain.graduate.Submit;
+import com.kyonggi.cspop.domain.student.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MiddleRepository extends JpaRepository<Middle, Long> {
+
+    Optional<Middle> findByStudent(Student student);
+}

--- a/src/main/java/com/kyonggi/cspop/repository/ProposalRepository.java
+++ b/src/main/java/com/kyonggi/cspop/repository/ProposalRepository.java
@@ -1,0 +1,13 @@
+package com.kyonggi.cspop.repository;
+
+import com.kyonggi.cspop.domain.graduate.Proposal;
+import com.kyonggi.cspop.domain.graduate.Submit;
+import com.kyonggi.cspop.domain.student.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProposalRepository extends JpaRepository<Proposal, Long> {
+
+    Optional<Proposal> findByStudent(Student student);
+}

--- a/src/main/java/com/kyonggi/cspop/repository/SubmitRepository.java
+++ b/src/main/java/com/kyonggi/cspop/repository/SubmitRepository.java
@@ -1,0 +1,12 @@
+package com.kyonggi.cspop.repository;
+
+import com.kyonggi.cspop.domain.graduate.Submit;
+import com.kyonggi.cspop.domain.student.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SubmitRepository extends JpaRepository<Submit, Long> {
+
+    Optional<Submit> findByStudent(Student student);
+}

--- a/src/main/java/com/kyonggi/cspop/service/dto/graduate/GraduationListResponseDto.java
+++ b/src/main/java/com/kyonggi/cspop/service/dto/graduate/GraduationListResponseDto.java
@@ -1,0 +1,48 @@
+package com.kyonggi.cspop.service.dto.graduate;
+
+import com.kyonggi.cspop.domain.graduate.Graduation;
+import com.kyonggi.cspop.domain.graduate.Status;
+import com.kyonggi.cspop.domain.schedule.Step;
+import com.kyonggi.cspop.domain.student.Student;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.repository.NoRepositoryBean;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GraduationListResponseDto {
+
+    private String loginId;
+
+    private String name;
+
+    private String professorName;
+
+    private LocalDate date;
+
+    private Step step;
+
+    private Status status;
+
+    private Boolean completion;
+
+    private Long studentId;
+
+    public static GraduationListResponseDto of(Student student, Graduation graduation) {
+        return new GraduationListResponseDto(
+                student.getLoginId(),
+                student.getName(),
+                graduation.getProfessorName(),
+                graduation.getDate(),
+                graduation.getStep(),
+                graduation.getStatus(),
+                graduation.getCompletion(),
+                student.getId()
+        );
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/service/dto/graduate/GraduationResponseDto.java
+++ b/src/main/java/com/kyonggi/cspop/service/dto/graduate/GraduationResponseDto.java
@@ -1,0 +1,48 @@
+package com.kyonggi.cspop.service.dto.graduate;
+
+import com.kyonggi.cspop.domain.graduate.Graduation;
+import com.kyonggi.cspop.domain.graduate.Status;
+import com.kyonggi.cspop.domain.schedule.Step;
+import com.kyonggi.cspop.domain.student.Department;
+import com.kyonggi.cspop.domain.student.Student;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GraduationResponseDto {
+
+    private String loginId;
+
+    private String name;
+
+    private Department department;
+
+    private String professorName;
+
+    private Boolean completion;
+
+    private LocalDate date;
+
+    private Status status;
+
+    private Step step;
+
+    public static GraduationResponseDto of(Student student, Graduation graduation) {
+        return new GraduationResponseDto(
+                student.getLoginId(),
+                student.getName(),
+                student.getDepartment(),
+                graduation.getProfessorName(),
+                graduation.getCompletion(),
+                graduation.getDate(),
+                graduation.getStatus(),
+                graduation.getStep()
+        );
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/service/dto/graduate/GraduationSaveResponseDto.java
+++ b/src/main/java/com/kyonggi/cspop/service/dto/graduate/GraduationSaveResponseDto.java
@@ -1,0 +1,18 @@
+package com.kyonggi.cspop.service.dto.graduate;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GraduationSaveResponseDto {
+
+    private Long id;
+
+    public static GraduationSaveResponseDto from(Long id) {
+        return new GraduationSaveResponseDto(id);
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/service/dto/graduate/GraduationsResponseDto.java
+++ b/src/main/java/com/kyonggi/cspop/service/dto/graduate/GraduationsResponseDto.java
@@ -1,0 +1,20 @@
+package com.kyonggi.cspop.service.dto.graduate;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GraduationsResponseDto {
+
+    private List<GraduationListResponseDto> graduationListResponseDtos;
+
+    public static GraduationsResponseDto from(List<GraduationListResponseDto> graduationListResponseDtos) {
+        return new GraduationsResponseDto(graduationListResponseDtos);
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/service/dto/graduate/finals/FinalSaveRequestDto.java
+++ b/src/main/java/com/kyonggi/cspop/service/dto/graduate/finals/FinalSaveRequestDto.java
@@ -1,0 +1,18 @@
+package com.kyonggi.cspop.service.dto.graduate.finals;
+
+import com.kyonggi.cspop.domain.graduate.Type;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FinalSaveRequestDto {
+
+    private String title;
+
+    private Type type;
+
+    private String qualification;
+
+    private Integer page;
+}

--- a/src/main/java/com/kyonggi/cspop/service/dto/graduate/finals/FinalSaveResponseDto.java
+++ b/src/main/java/com/kyonggi/cspop/service/dto/graduate/finals/FinalSaveResponseDto.java
@@ -1,0 +1,18 @@
+package com.kyonggi.cspop.service.dto.graduate.finals;
+
+import com.kyonggi.cspop.service.dto.graduate.middle.MiddleSaveResponseDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FinalSaveResponseDto {
+    private Long id;
+
+    public static FinalSaveResponseDto from(Long id) {
+        return new FinalSaveResponseDto(id);
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/service/dto/graduate/middle/MiddleSaveRequestDto.java
+++ b/src/main/java/com/kyonggi/cspop/service/dto/graduate/middle/MiddleSaveRequestDto.java
@@ -1,0 +1,18 @@
+package com.kyonggi.cspop.service.dto.graduate.middle;
+
+import com.kyonggi.cspop.domain.graduate.Type;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MiddleSaveRequestDto {
+
+    private String title;
+
+    private Type type;
+
+    private String text;
+
+    private String plan;
+}

--- a/src/main/java/com/kyonggi/cspop/service/dto/graduate/middle/MiddleSaveResponseDto.java
+++ b/src/main/java/com/kyonggi/cspop/service/dto/graduate/middle/MiddleSaveResponseDto.java
@@ -1,0 +1,19 @@
+package com.kyonggi.cspop.service.dto.graduate.middle;
+
+import com.kyonggi.cspop.service.dto.graduate.proposal.ProposalSaveResponseDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MiddleSaveResponseDto {
+
+    private Long id;
+
+    public static MiddleSaveResponseDto from(Long id) {
+        return new MiddleSaveResponseDto(id);
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/service/dto/graduate/proposal/ProposalSaveRequestDto.java
+++ b/src/main/java/com/kyonggi/cspop/service/dto/graduate/proposal/ProposalSaveRequestDto.java
@@ -1,0 +1,21 @@
+package com.kyonggi.cspop.service.dto.graduate.proposal;
+
+import com.kyonggi.cspop.domain.graduate.Type;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.kyonggi.cspop.controller.dto.ValidateMessage.EMPTY_MESSAGE;
+
+@Getter
+@AllArgsConstructor
+public class ProposalSaveRequestDto {
+
+    private String title;
+
+    private Type type;
+
+    private String qualification;
+
+    private String content;
+}

--- a/src/main/java/com/kyonggi/cspop/service/dto/graduate/proposal/ProposalSaveResponseDto.java
+++ b/src/main/java/com/kyonggi/cspop/service/dto/graduate/proposal/ProposalSaveResponseDto.java
@@ -1,0 +1,18 @@
+package com.kyonggi.cspop.service.dto.graduate.proposal;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProposalSaveResponseDto {
+
+    private Long id;
+
+    public static ProposalSaveResponseDto from(Long id) {
+        return new ProposalSaveResponseDto(id);
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/service/dto/graduate/submit/SubmitResponseDto.java
+++ b/src/main/java/com/kyonggi/cspop/service/dto/graduate/submit/SubmitResponseDto.java
@@ -1,0 +1,18 @@
+package com.kyonggi.cspop.service.dto.graduate.submit;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SubmitResponseDto {
+
+    private Long id;
+
+    public static SubmitResponseDto from(Long id) {
+        return new SubmitResponseDto(id);
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/service/dto/graduate/submit/SubmitUpdateRequestDto.java
+++ b/src/main/java/com/kyonggi/cspop/service/dto/graduate/submit/SubmitUpdateRequestDto.java
@@ -1,0 +1,20 @@
+package com.kyonggi.cspop.service.dto.graduate.submit;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class SubmitUpdateRequestDto {
+
+    private LocalDate graduateDate;
+
+    private Boolean completion;
+
+    private Boolean approve;
+
+    private String reason;
+}

--- a/src/main/java/com/kyonggi/cspop/service/graduate/FinalService.java
+++ b/src/main/java/com/kyonggi/cspop/service/graduate/FinalService.java
@@ -1,0 +1,81 @@
+package com.kyonggi.cspop.service.graduate;
+
+import com.kyonggi.cspop.domain.graduate.Final;
+import com.kyonggi.cspop.domain.graduate.Middle;
+import com.kyonggi.cspop.domain.graduate.Status;
+import com.kyonggi.cspop.domain.schedule.Step;
+import com.kyonggi.cspop.domain.student.Student;
+import com.kyonggi.cspop.exception.NoSuchFinalException;
+import com.kyonggi.cspop.exception.NoSuchMiddleException;
+import com.kyonggi.cspop.exception.NoSuchStudentIdException;
+import com.kyonggi.cspop.repository.FinalRepository;
+import com.kyonggi.cspop.repository.MiddleRepository;
+import com.kyonggi.cspop.repository.StudentRepository;
+import com.kyonggi.cspop.service.dto.graduate.finals.FinalSaveRequestDto;
+import com.kyonggi.cspop.service.dto.graduate.finals.FinalSaveResponseDto;
+import com.kyonggi.cspop.service.dto.graduate.middle.MiddleSaveRequestDto;
+import com.kyonggi.cspop.service.dto.graduate.middle.MiddleSaveResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.kyonggi.cspop.domain.schedule.Step.PASS;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FinalService {
+
+    private final StudentRepository studentRepository;
+    private final FinalRepository finalRepository;
+
+    public FinalSaveResponseDto saveFinal(
+            FinalSaveRequestDto finalSaveRequestDto,
+            Long studentId
+    ) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new NoSuchStudentIdException(studentId));
+
+        Final saveFinal = new Final(
+                finalSaveRequestDto.getTitle(),
+                finalSaveRequestDto.getType(),
+                finalSaveRequestDto.getQualification(),
+                finalSaveRequestDto.getPage(),
+                student
+        );
+
+        Long saveId = finalRepository.save(saveFinal)
+                .getId();
+
+        return FinalSaveResponseDto.from(saveId);
+    }
+
+    public void approveFinal(Long studentId) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new NoSuchStudentIdException(studentId));
+        Final findFinal = finalRepository.findByStudent(student)
+                .orElseThrow(() -> new NoSuchFinalException(studentId));
+
+        changeFinal(student);
+        findFinal.changeApprove(true);
+    }
+
+    private void changeFinal(Student student) {
+        student.changeGraduationStep(PASS);
+        student.changeGraduationStatus(Status.APPROVAL);
+    }
+
+    public void rejectFinal(Long studentId, String reason) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new NoSuchStudentIdException(studentId));
+        Final findFinal = finalRepository.findByStudent(student)
+                .orElseThrow(() -> new NoSuchFinalException(studentId));
+
+        changeFinal(reason, findFinal);
+    }
+
+    private void changeFinal(String reason, Final findFinal) {
+        findFinal.changeApprove(false);
+        findFinal.changeReason(reason);
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/service/graduate/GraduationService.java
+++ b/src/main/java/com/kyonggi/cspop/service/graduate/GraduationService.java
@@ -39,6 +39,7 @@ public class GraduationService {
         return GraduationSaveResponseDto.from(saveId);
     }
 
+    @Transactional(readOnly = true)
     public GraduationsResponseDto findAllGraduation() {
         List<GraduationListResponseDto> graduationListResponseDtos = graduationRepository.findAll()
                 .stream()
@@ -48,6 +49,7 @@ public class GraduationService {
         return GraduationsResponseDto.from(graduationListResponseDtos);
     }
 
+    @Transactional(readOnly = true)
     public GraduationResponseDto findGraduation(Long studentId) {
         Student student = studentRepository.findById(studentId)
                 .orElseThrow(() -> new NoSuchStudentIdException(studentId));

--- a/src/main/java/com/kyonggi/cspop/service/graduate/GraduationService.java
+++ b/src/main/java/com/kyonggi/cspop/service/graduate/GraduationService.java
@@ -1,0 +1,35 @@
+package com.kyonggi.cspop.service.graduate;
+
+import com.kyonggi.cspop.domain.graduate.Graduation;
+import com.kyonggi.cspop.domain.graduate.Method;
+import com.kyonggi.cspop.domain.student.Student;
+import com.kyonggi.cspop.exception.NoSuchStudentIdException;
+import com.kyonggi.cspop.repository.GraduationRepository;
+import com.kyonggi.cspop.repository.StudentRepository;
+import com.kyonggi.cspop.service.dto.graduate.GraduationSaveResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.kyonggi.cspop.domain.graduate.Status.UN_APPROVAL;
+import static com.kyonggi.cspop.domain.schedule.Step.RECEIVE;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GraduationService {
+
+    private final GraduationRepository graduationRepository;
+    private final StudentRepository studentRepository;
+
+    public GraduationSaveResponseDto saveGraduation(String method, Long id) {
+        Student student = studentRepository.findById(id)
+                .orElseThrow(() -> new NoSuchStudentIdException(id));
+        Graduation graduation = new Graduation(Method.from(method), UN_APPROVAL, RECEIVE, null, null,
+                null, student);
+
+        Long saveId = graduationRepository.save(graduation)
+                .getId();
+        return GraduationSaveResponseDto.from(saveId);
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/service/graduate/GraduationService.java
+++ b/src/main/java/com/kyonggi/cspop/service/graduate/GraduationService.java
@@ -3,13 +3,19 @@ package com.kyonggi.cspop.service.graduate;
 import com.kyonggi.cspop.domain.graduate.Graduation;
 import com.kyonggi.cspop.domain.graduate.Method;
 import com.kyonggi.cspop.domain.student.Student;
+import com.kyonggi.cspop.exception.NoSuchGraduationException;
 import com.kyonggi.cspop.exception.NoSuchStudentIdException;
 import com.kyonggi.cspop.repository.GraduationRepository;
 import com.kyonggi.cspop.repository.StudentRepository;
+import com.kyonggi.cspop.service.dto.graduate.GraduationListResponseDto;
+import com.kyonggi.cspop.service.dto.graduate.GraduationResponseDto;
 import com.kyonggi.cspop.service.dto.graduate.GraduationSaveResponseDto;
+import com.kyonggi.cspop.service.dto.graduate.GraduationsResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static com.kyonggi.cspop.domain.graduate.Status.UN_APPROVAL;
 import static com.kyonggi.cspop.domain.schedule.Step.RECEIVE;
@@ -31,5 +37,23 @@ public class GraduationService {
         Long saveId = graduationRepository.save(graduation)
                 .getId();
         return GraduationSaveResponseDto.from(saveId);
+    }
+
+    public GraduationsResponseDto findAllGraduation() {
+        List<GraduationListResponseDto> graduationListResponseDtos = graduationRepository.findAll()
+                .stream()
+                .map(graduation -> GraduationListResponseDto.of(graduation.getStudent(), graduation))
+                .toList();
+
+        return GraduationsResponseDto.from(graduationListResponseDtos);
+    }
+
+    public GraduationResponseDto findGraduation(Long studentId) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new NoSuchStudentIdException(studentId));
+
+        Graduation graduation = graduationRepository.findByStudent(student)
+                .orElseThrow(() -> new NoSuchGraduationException(studentId));
+        return GraduationResponseDto.of(student, graduation);
     }
 }

--- a/src/main/java/com/kyonggi/cspop/service/graduate/MiddleService.java
+++ b/src/main/java/com/kyonggi/cspop/service/graduate/MiddleService.java
@@ -1,0 +1,70 @@
+package com.kyonggi.cspop.service.graduate;
+
+import com.kyonggi.cspop.domain.graduate.Middle;
+import com.kyonggi.cspop.domain.graduate.Proposal;
+import com.kyonggi.cspop.domain.student.Student;
+import com.kyonggi.cspop.exception.NoSuchMiddleException;
+import com.kyonggi.cspop.exception.NoSuchStudentIdException;
+import com.kyonggi.cspop.repository.MiddleRepository;
+import com.kyonggi.cspop.repository.StudentRepository;
+import com.kyonggi.cspop.service.dto.graduate.middle.MiddleSaveRequestDto;
+import com.kyonggi.cspop.service.dto.graduate.middle.MiddleSaveResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.kyonggi.cspop.domain.schedule.Step.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MiddleService {
+
+    private final StudentRepository studentRepository;
+    private final MiddleRepository middleRepository;
+
+    public MiddleSaveResponseDto saveMiddle(
+            MiddleSaveRequestDto middleSaveRequestDto,
+            Long studentId
+    ) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new NoSuchStudentIdException(studentId));
+
+        Middle middle = new Middle(
+                middleSaveRequestDto.getTitle(),
+                middleSaveRequestDto.getType(),
+                middleSaveRequestDto.getText(),
+                middleSaveRequestDto.getPlan(),
+                student
+        );
+
+        Long saveId = middleRepository.save(middle)
+                .getId();
+
+        return MiddleSaveResponseDto.from(saveId);
+    }
+
+    public void approveMiddle(Long studentId) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new NoSuchStudentIdException(studentId));
+        Middle middle = middleRepository.findByStudent(student)
+                .orElseThrow(() -> new NoSuchMiddleException(studentId));
+
+        student.changeGraduationStep(FINAL);
+        middle.changeApprove(true);
+    }
+
+    public void rejectMiddle(Long studentId, String reason) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new NoSuchStudentIdException(studentId));
+        Middle middle = middleRepository.findByStudent(student)
+                .orElseThrow(() -> new NoSuchMiddleException(studentId));
+
+        changeMiddle(reason, middle);
+    }
+
+    private void changeMiddle(String reason, Middle middle) {
+        middle.changeApprove(false);
+        middle.changeReason(reason);
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/service/graduate/ProposalService.java
+++ b/src/main/java/com/kyonggi/cspop/service/graduate/ProposalService.java
@@ -1,0 +1,70 @@
+package com.kyonggi.cspop.service.graduate;
+
+import com.kyonggi.cspop.domain.graduate.Proposal;
+import com.kyonggi.cspop.domain.schedule.Step;
+import com.kyonggi.cspop.domain.student.Student;
+import com.kyonggi.cspop.exception.NoSuchProposalException;
+import com.kyonggi.cspop.exception.NoSuchStudentIdException;
+import com.kyonggi.cspop.exception.NoSuchSubmitException;
+import com.kyonggi.cspop.repository.ProposalRepository;
+import com.kyonggi.cspop.repository.StudentRepository;
+import com.kyonggi.cspop.service.dto.graduate.proposal.ProposalSaveRequestDto;
+import com.kyonggi.cspop.service.dto.graduate.proposal.ProposalSaveResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.kyonggi.cspop.domain.schedule.Step.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ProposalService {
+
+    private final StudentRepository studentRepository;
+    private final ProposalRepository proposalRepository;
+
+    public ProposalSaveResponseDto saveProposal(
+            ProposalSaveRequestDto proposalSaveRequestDto,
+            Long studentId
+    ) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new NoSuchStudentIdException(studentId));
+
+        Proposal proposal = new Proposal(
+                proposalSaveRequestDto.getTitle(),
+                proposalSaveRequestDto.getType(),
+                proposalSaveRequestDto.getQualification(),
+                proposalSaveRequestDto.getContent(),
+                student
+        );
+        Long saveId = proposalRepository.save(proposal)
+                .getId();
+
+        return ProposalSaveResponseDto.from(saveId);
+    }
+
+    public void approveProposal(Long studentId) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new NoSuchStudentIdException(studentId));
+        Proposal proposal = proposalRepository.findByStudent(student)
+                .orElseThrow(() -> new NoSuchProposalException(studentId));
+
+        student.changeGraduationStep(MIDDLE);
+        proposal.changeApprove(true);
+    }
+
+    public void rejectProposal(Long studentId, String reason) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new NoSuchStudentIdException(studentId));
+        Proposal proposal = proposalRepository.findByStudent(student)
+                .orElseThrow(() -> new NoSuchProposalException(studentId));
+
+        changeProposal(reason, proposal);
+    }
+
+    private void changeProposal(String reason, Proposal proposal) {
+        proposal.changeApprove(false);
+        proposal.changeReason(reason);
+    }
+}

--- a/src/main/java/com/kyonggi/cspop/service/graduate/SubmitService.java
+++ b/src/main/java/com/kyonggi/cspop/service/graduate/SubmitService.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.Optional;
 
+import static com.kyonggi.cspop.domain.schedule.Step.PROPOSAL;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -33,5 +35,28 @@ public class SubmitService {
                 .getId();
 
         return SubmitResponseDto.from(id);
+    }
+
+    public void approveSubmit(SubmitUpdateRequestDto submitUpdateRequestDto, Long studentId) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new NoSuchStudentIdException(studentId));
+
+        Submit submit = submitRepository.findByStudent(student)
+                .orElseThrow(() -> new NoSuchSubmitException(studentId));
+
+        changeSubmit(submitUpdateRequestDto, submit);
+        changeGraduation(submitUpdateRequestDto, student);
+    }
+
+    private void changeSubmit(SubmitUpdateRequestDto submitUpdateRequestDto, Submit submit) {
+        submit.changeGraduateDate(submitUpdateRequestDto.getGraduateDate());
+        submit.changeApprove(submitUpdateRequestDto.getApprove());
+        submit.changeCompletion(submitUpdateRequestDto.getCompletion());
+        submit.changeReason(submitUpdateRequestDto.getReason());
+    }
+
+    private static void changeGraduation(SubmitUpdateRequestDto submitUpdateRequestDto, Student student) {
+        student.changeGraduationStep(PROPOSAL);
+        student.changeGraduationSubmit(submitUpdateRequestDto.getGraduateDate(), student.getName());
     }
 }

--- a/src/main/java/com/kyonggi/cspop/service/graduate/SubmitService.java
+++ b/src/main/java/com/kyonggi/cspop/service/graduate/SubmitService.java
@@ -1,0 +1,37 @@
+package com.kyonggi.cspop.service.graduate;
+
+import com.kyonggi.cspop.domain.graduate.Submit;
+import com.kyonggi.cspop.domain.student.Student;
+import com.kyonggi.cspop.exception.NoSuchStudentIdException;
+import com.kyonggi.cspop.exception.NoSuchSubmitException;
+import com.kyonggi.cspop.repository.StudentRepository;
+import com.kyonggi.cspop.repository.SubmitRepository;
+import com.kyonggi.cspop.service.dto.graduate.GraduationResponseDto;
+import com.kyonggi.cspop.service.dto.graduate.submit.SubmitResponseDto;
+import com.kyonggi.cspop.service.dto.graduate.submit.SubmitUpdateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SubmitService {
+
+    private final SubmitRepository submitRepository;
+    private final StudentRepository studentRepository;
+
+    public SubmitResponseDto saveSubmit(Long studentId) {
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new NoSuchStudentIdException(studentId));
+
+        Submit submit = new Submit(student.getName(), student);
+        Long id = submitRepository.save(submit)
+                .getId();
+
+        return SubmitResponseDto.from(id);
+    }
+}

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -59,3 +59,19 @@ values ('finalReport','middleReport','other','pass','proposal','receive', 3);
 insert into graduation
     (created_date, last_modified_date, method, status, step, capstone_completion, graduate_date, professor_name, student_id)
 values (NOW(), NOW(), 'THESIS','UN_APPROVAL','RECEIVE',false, null, null, 1);
+
+insert into submit
+    (approve,capstone_completion,created_date,graduate_date,last_modified_date,professor_name,reject_reason,student_id)
+values (true,true,NOW(),'2024-06-14',NOW(),'dummy',NULL,1);
+
+insert into middle_form
+    (approve,created_date,last_modified_date,plan,reject_reason,student_id,text,title,type)
+values (true,NOW(),NOW(),'content',NULL,1,'text','title','IMPLEMENT');
+
+insert into final_form
+    (approve,created_date,last_modified_date,page,qualification,reject_reason,student_id,title,type)
+values (true,NOW(),NOW(),1,'qualification',NULL,1,'title','IMPLEMENT');
+
+insert into proposal
+    (approve,created_date,last_modified_date,content,qualification,reject_reason,student_id,title,type)
+values (true,NOW(),NOW(),'content','qualification',NULL,1,'title','IMPLEMENT');

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -55,3 +55,7 @@ values (NOW(),'2024-08-14',NOW(),'2024-06-14','FINISH','PASS');
 insert into schedule_board
     (final_report, middle_report, other_qualification, pass, proposal, receive, schedule_board_id)
 values ('finalReport','middleReport','other','pass','proposal','receive', 3);
+
+insert into graduation
+    (created_date, last_modified_date, method, status, step, capstone_completion, graduate_date, professor_name, student_id)
+values (NOW(), NOW(), 'THESIS','UN_APPROVAL','RECEIVE',false, null, null, 1);

--- a/src/main/resources/sql/init.sql
+++ b/src/main/resources/sql/init.sql
@@ -93,9 +93,9 @@ create table schedule_board
 create table final_form
 (
     final_form_id bigint not null auto_increment,
-    approve boolean not null,
+    approve boolean,
     page integer not null,
-    type tinyint not null check (type between 0 and 1),
+    type enum ('IMPLEMENT','INVESTIGATE') not null,
     created_date timestamp(6) not null,
     last_modified_date timestamp(6) not null,
     student_id bigint not null unique,
@@ -122,8 +122,8 @@ create table graduation
 
 create table middle_form
 (
-    approve boolean not null,
-    type tinyint not null check (type between 0 and 1),
+    approve boolean,
+    type enum ('IMPLEMENT','INVESTIGATE') not null,
     created_date timestamp(6) not null,
     last_modified_date timestamp(6) not null,
     middle_form_id bigint not null auto_increment,
@@ -137,8 +137,8 @@ create table middle_form
 
 create table proposal
 (
-    approve boolean not null,
-    type tinyint not null check (type between 0 and 1),
+    approve boolean,
+    type enum ('IMPLEMENT','INVESTIGATE') not null,
     created_date timestamp(6) not null,
     last_modified_date timestamp(6) not null,
     proposal_id bigint not null auto_increment,
@@ -152,13 +152,13 @@ create table proposal
 
 create table submit
 (
-    approve boolean not null,
+    approve boolean,
     capstone_completion boolean,
-    graduate_date date not null,
+    graduate_date date,
     created_date timestamp(6) not null,
     last_modified_date timestamp(6) not null,
     submit_id bigint not null auto_increment,
-    professor_name varchar(10) not null,
+    professor_name varchar(10),
     reject_reason varchar(100),
     student_id bigint not null unique,
     primary key (submit_id)
@@ -166,18 +166,18 @@ create table submit
 
 alter table comment
     add constraint fk_comment_notice_board
-    foreign key (notice_board_id)
-    references notice_board (notice_board_id);
+        foreign key (notice_board_id)
+            references notice_board (notice_board_id);
 
 alter table comment
     add constraint fk_comment_student
-    foreign key (student_id)
-    references student (student_id);
+        foreign key (student_id)
+            references student (student_id);
 
 alter table notice_board
     add constraint fk_notice_board_student
-    foreign key (student_id)
-    references student (student_id);
+        foreign key (student_id)
+            references student (student_id);
 
 alter table final_form
     add constraint fk_final_student

--- a/src/main/resources/sql/init.sql
+++ b/src/main/resources/sql/init.sql
@@ -92,11 +92,11 @@ create table schedule_board
 
 create table final_form
 (
+    final_form_id bigint not null auto_increment,
     approve boolean not null,
     page integer not null,
     type tinyint not null check (type between 0 and 1),
     created_date timestamp(6) not null,
-    final_form_id bigint not null auto_increment,
     last_modified_date timestamp(6) not null,
     student_id bigint not null unique,
     qualification varchar(45) not null,
@@ -107,17 +107,17 @@ create table final_form
 
 create table graduation
 (
+    graduation_id bigint not null auto_increment,
     capstone_completion boolean,
     graduate_date date,
     created_date timestamp(6) not null,
-    id bigint not null auto_increment,
     last_modified_date timestamp(6) not null,
     student_id bigint not null unique,
     professor_name varchar(10),
     method enum ('OTHER','THESIS'),
     status enum ('APPROVAL','REJECT','UN_APPROVAL'),
     step enum ('FINAL','MIDDLE','OTHER_QUALIFICATION','PASS','PROPOSAL','RECEIVE'),
-    primary key (id)
+    primary key (graduation_id)
 );
 
 create table middle_form

--- a/src/main/resources/sql/init.sql
+++ b/src/main/resources/sql/init.sql
@@ -160,6 +160,7 @@ create table submit
     submit_id bigint not null auto_increment,
     professor_name varchar(10) not null,
     reject_reason varchar(100),
+    student_id bigint not null unique,
     primary key (submit_id)
 );
 

--- a/src/main/resources/sql/init.sql
+++ b/src/main/resources/sql/init.sql
@@ -1,3 +1,8 @@
+DROP TABLE IF EXISTS final_form;
+DROP TABLE IF EXISTS middle_form;
+DROP TABLE IF EXISTS proposal;
+DROP TABLE IF EXISTS submit;
+DROP TABLE IF EXISTS graduation;
 DROP TABLE IF EXISTS refresh_token;
 DROP TABLE IF EXISTS comment;
 DROP TABLE IF EXISTS notice_board;
@@ -75,7 +80,7 @@ create table schedule
 
 create table schedule_board
 (
-    schedule_board_id bigint auto_increment,
+    schedule_board_id bigint not null auto_increment,
     final_report text not null,
     middle_report text not null,
     pass text not null,
@@ -83,6 +88,79 @@ create table schedule_board
     receive text not null,
     other_qualification text not null,
     primary key (schedule_board_id)
+);
+
+create table final_form
+(
+    approve boolean not null,
+    page integer not null,
+    type tinyint not null check (type between 0 and 1),
+    created_date timestamp(6) not null,
+    final_form_id bigint not null auto_increment,
+    last_modified_date timestamp(6) not null,
+    student_id bigint not null unique,
+    qualification varchar(45) not null,
+    reject_reason varchar(100),
+    title varchar(100) not null,
+    primary key (final_form_id)
+);
+
+create table graduation
+(
+    capstone_completion boolean,
+    graduate_date date,
+    created_date timestamp(6) not null,
+    id bigint not null auto_increment,
+    last_modified_date timestamp(6) not null,
+    student_id bigint not null unique,
+    professor_name varchar(10),
+    method enum ('OTHER','THESIS'),
+    status enum ('APPROVAL','REJECT','UN_APPROVAL'),
+    step enum ('FINAL','MIDDLE','OTHER_QUALIFICATION','PASS','PROPOSAL','RECEIVE'),
+    primary key (id)
+);
+
+create table middle_form
+(
+    approve boolean not null,
+    type tinyint not null check (type between 0 and 1),
+    created_date timestamp(6) not null,
+    last_modified_date timestamp(6) not null,
+    middle_form_id bigint not null auto_increment,
+    student_id bigint not null unique,
+    reject_reason varchar(100),
+    title varchar(100) not null,
+    plan varchar(500) not null,
+    text varchar(500) not null,
+    primary key (middle_form_id)
+);
+
+create table proposal
+(
+    approve boolean not null,
+    type tinyint not null check (type between 0 and 1),
+    created_date timestamp(6) not null,
+    last_modified_date timestamp(6) not null,
+    proposal_id bigint not null auto_increment,
+    student_id bigint not null unique,
+    content varchar(45) not null,
+    qualification varchar(45) not null,
+    reject_reason varchar(100),
+    title varchar(100) not null,
+    primary key (proposal_id)
+);
+
+create table submit
+(
+    approve boolean not null,
+    capstone_completion boolean,
+    graduate_date date not null,
+    created_date timestamp(6) not null,
+    last_modified_date timestamp(6) not null,
+    submit_id bigint not null auto_increment,
+    professor_name varchar(10) not null,
+    reject_reason varchar(100),
+    primary key (submit_id)
 );
 
 alter table comment
@@ -99,3 +177,23 @@ alter table notice_board
     add constraint fk_notice_board_student
     foreign key (student_id)
     references student (student_id);
+
+alter table final_form
+    add constraint fk_final_student
+        foreign key (student_id)
+            references student (student_id);
+
+alter table graduation
+    add constraint fk_graduation_student
+        foreign key (student_id)
+            references student (student_id);
+
+alter table middle_form
+    add constraint fk_middle_student
+        foreign key (student_id)
+            references student (student_id);
+
+alter table proposal
+    add constraint fk_proposal_student
+        foreign key (student_id)
+            references student (student_id);

--- a/src/test/java/com/kyonggi/cspop/domain/graduate/FinalTest.java
+++ b/src/test/java/com/kyonggi/cspop/domain/graduate/FinalTest.java
@@ -1,0 +1,35 @@
+package com.kyonggi.cspop.domain.graduate;
+
+import com.kyonggi.cspop.domain.student.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static java.time.LocalDate.now;
+import static org.junit.jupiter.api.Assertions.*;
+
+class FinalTest {
+
+    @Test
+    @DisplayName("최종 보고서를 생성한다.")
+    void consturct() {
+        // given
+        Student student = new Student(
+                1L,
+                "201811111",
+                "123",
+                "111&!a",
+                now().minusDays(1),
+                Department.AI,
+                Grade.FIRTH,
+                PhoneNumber.from("010-1111-1111"),
+                "dummy",
+                Email.from("1@naver.com"),
+                Classification.UNDERGRADUATE_STUDENT,
+                RoleType.ADMIN
+        );
+
+        // then
+        assertDoesNotThrow(() -> new Final("title", Type.from("구현"), "qualification", 1, student));
+    }
+}

--- a/src/test/java/com/kyonggi/cspop/domain/graduate/GraduationTest.java
+++ b/src/test/java/com/kyonggi/cspop/domain/graduate/GraduationTest.java
@@ -1,0 +1,117 @@
+package com.kyonggi.cspop.domain.graduate;
+
+import com.kyonggi.cspop.domain.schedule.Step;
+import com.kyonggi.cspop.domain.student.*;
+import com.kyonggi.cspop.exception.NotReachedGraduationException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static java.time.LocalDate.now;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GraduationTest {
+
+    @Test
+    @DisplayName("졸업 날짜가 현재보다 이전이면 예외가 발생한다.")
+    void throwException_invalidDate() {
+        // given
+        Student student = new Student(
+                1L,
+                "201811111",
+                "123",
+                "111&!a",
+                now().minusDays(1),
+                Department.AI,
+                Grade.FIRTH,
+                PhoneNumber.from("010-1111-1111"),
+                "dummy",
+                Email.from("1@naver.com"),
+                Classification.UNDERGRADUATE_STUDENT,
+                RoleType.ADMIN
+        );
+
+        // then
+        assertThatThrownBy(() -> new Graduation(
+                        Method.THESIS,
+                        Status.UN_APPROVAL,
+                        Step.RECEIVE,
+                        false,
+                        now().minusDays(1),
+                        "professorName",
+                        student
+                )).isInstanceOf(NotReachedGraduationException.class)
+                .hasMessage(String.format("졸업 날짜는 현재 시점보다 빠를 수 없습니다. 졸업날짜 = {%s}", now().minusDays(1)));
+    }
+
+    @Test
+    @DisplayName("졸업자의 승인 상태를 수정한다.")
+    void changeStatus() {
+        // given
+        Student student = new Student(
+                1L,
+                "201811111",
+                "123",
+                "111&!a",
+                now().minusDays(1),
+                Department.AI,
+                Grade.FIRTH,
+                PhoneNumber.from("010-1111-1111"),
+                "dummy",
+                Email.from("1@naver.com"),
+                Classification.UNDERGRADUATE_STUDENT,
+                RoleType.ADMIN
+        );
+        Graduation graduation = new Graduation(
+                Method.THESIS,
+                Status.UN_APPROVAL,
+                Step.RECEIVE,
+                false,
+                now().plusDays(1),
+                "professorName",
+                student
+        );
+        Status changeStatus = Status.REJECT;
+
+        // when
+        graduation.changeStatus(changeStatus);
+
+        // then
+        assertThat(graduation.getStatus())
+                .isEqualTo(changeStatus);
+    }
+    
+    @Test
+    @DisplayName("졸업자 조회를 생성한다.")
+    void construct() {
+        // given
+        Student student = new Student(
+                1L,
+                "201811111",
+                "123",
+                "111&!a",
+                now().minusDays(1),
+                Department.AI,
+                Grade.FIRTH,
+                PhoneNumber.from("010-1111-1111"),
+                "dummy",
+                Email.from("1@naver.com"),
+                Classification.UNDERGRADUATE_STUDENT,
+                RoleType.ADMIN
+        );
+
+        assertDoesNotThrow(() -> new Graduation(
+                Method.THESIS,
+                Status.UN_APPROVAL,
+                Step.RECEIVE,
+                false,
+                now().plusDays(1),
+                "professorName",
+                student
+        ));
+    }
+}

--- a/src/test/java/com/kyonggi/cspop/domain/graduate/MiddleTest.java
+++ b/src/test/java/com/kyonggi/cspop/domain/graduate/MiddleTest.java
@@ -1,0 +1,35 @@
+package com.kyonggi.cspop.domain.graduate;
+
+import com.kyonggi.cspop.domain.student.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static java.time.LocalDate.now;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MiddleTest {
+
+    @Test
+    @DisplayName("중간 보고서를 생성한다.")
+    void construct() {
+        // given
+        Student student = new Student(
+                1L,
+                "201811111",
+                "123",
+                "111&!a",
+                now().minusDays(1),
+                Department.AI,
+                Grade.FIRTH,
+                PhoneNumber.from("010-1111-1111"),
+                "dummy",
+                Email.from("1@naver.com"),
+                Classification.UNDERGRADUATE_STUDENT,
+                RoleType.ADMIN
+        );
+
+        // then
+        assertDoesNotThrow(() -> new Middle("title", Type.from("구현"), "text", "plan", student));
+    }
+}

--- a/src/test/java/com/kyonggi/cspop/domain/graduate/ProposalTest.java
+++ b/src/test/java/com/kyonggi/cspop/domain/graduate/ProposalTest.java
@@ -1,0 +1,65 @@
+package com.kyonggi.cspop.domain.graduate;
+
+import com.kyonggi.cspop.domain.student.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static java.time.LocalDate.now;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProposalTest {
+
+    @Test
+    @DisplayName("제안서 제출을 생성한다.")
+    void construct() {
+        // given
+        Student student = new Student(
+                1L,
+                "201811111",
+                "123",
+                "111&!a",
+                now().minusDays(1),
+                Department.AI,
+                Grade.FIRTH,
+                PhoneNumber.from("010-1111-1111"),
+                "dummy",
+                Email.from("1@naver.com"),
+                Classification.UNDERGRADUATE_STUDENT,
+                RoleType.ADMIN
+        );
+
+        // then
+        Assertions.assertDoesNotThrow(() -> new Proposal("title", Type.from("구현"), "qualification", "content", student));
+    }
+
+    @Test
+    @DisplayName("반려 사유를 수정한다.")
+    void changeReason() {
+        // given
+        Student student = new Student(
+                1L,
+                "201811111",
+                "123",
+                "111&!a",
+                now().minusDays(1),
+                Department.AI,
+                Grade.FIRTH,
+                PhoneNumber.from("010-1111-1111"),
+                "dummy",
+                Email.from("1@naver.com"),
+                Classification.UNDERGRADUATE_STUDENT,
+                RoleType.ADMIN
+        );
+        Proposal proposal = new Proposal("title", Type.from("구현"), "qualification", "content", student);
+        String changeReason = "reason";
+
+        // when
+        proposal.changeReason(changeReason);
+
+        // then
+        assertThat(proposal.getReason())
+                .isEqualTo(changeReason);
+    }
+}

--- a/src/test/java/com/kyonggi/cspop/domain/graduate/SubmitTest.java
+++ b/src/test/java/com/kyonggi/cspop/domain/graduate/SubmitTest.java
@@ -1,0 +1,65 @@
+package com.kyonggi.cspop.domain.graduate;
+
+import com.kyonggi.cspop.domain.student.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static java.time.LocalDate.now;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SubmitTest {
+
+    @Test
+    @DisplayName("신청 접수를 생성한다.")
+    void construct() {
+        // given
+        Student student = new Student(
+                1L,
+                "201811111",
+                "123",
+                "111&!a",
+                now().minusDays(1),
+                Department.AI,
+                Grade.FIRTH,
+                PhoneNumber.from("010-1111-1111"),
+                "dummy",
+                Email.from("1@naver.com"),
+                Classification.UNDERGRADUATE_STUDENT,
+                RoleType.ADMIN
+        );
+
+        // then
+        assertDoesNotThrow(() -> new Submit("name", student));
+    }
+
+    @Test
+    @DisplayName("신청 접수 승인 여부를 수정한다.")
+    void changeApprove() {
+        // given
+        Student student = new Student(
+                1L,
+                "201811111",
+                "123",
+                "111&!a",
+                now().minusDays(1),
+                Department.AI,
+                Grade.FIRTH,
+                PhoneNumber.from("010-1111-1111"),
+                "dummy",
+                Email.from("1@naver.com"),
+                Classification.UNDERGRADUATE_STUDENT,
+                RoleType.ADMIN
+        );
+        Submit submit = new Submit("name", student);
+        Boolean changeApprove = true;
+
+        // when
+        submit.changeApprove(changeApprove);
+
+        // then
+        assertThat(submit.getApprove())
+                .isEqualTo(changeApprove);
+    }
+}

--- a/src/test/java/com/kyonggi/cspop/repository/GraduationRepositoryTest.java
+++ b/src/test/java/com/kyonggi/cspop/repository/GraduationRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.kyonggi.cspop.repository;
+
+import com.kyonggi.cspop.domain.graduate.Graduation;
+import com.kyonggi.cspop.domain.graduate.Method;
+import com.kyonggi.cspop.domain.graduate.Status;
+import com.kyonggi.cspop.domain.schedule.Step;
+import com.kyonggi.cspop.domain.student.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static java.time.LocalDate.now;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GraduationRepositoryTest extends RepositoryTest {
+
+    Student student;
+    Graduation graduation;
+
+    @BeforeEach
+    void setUp() {
+        student = new Student(
+                1L,
+                "201811111",
+                "123",
+                "111&!a",
+                now().minusDays(1),
+                Department.AI,
+                Grade.FIRTH,
+                PhoneNumber.from("010-1111-1111"),
+                "dummy",
+                Email.from("1@naver.com"),
+                Classification.UNDERGRADUATE_STUDENT,
+                RoleType.ADMIN
+        );
+        graduation = new Graduation(
+                Method.THESIS,
+                Status.UN_APPROVAL,
+                Step.RECEIVE,
+                false,
+                now().plusDays(1),
+                "professor",
+                student
+        );
+        studentRepository.save(student);
+    }
+
+    @Test
+    @DisplayName("졸업을 신청한 학생을 찾는다.")
+    void findByStudent() {
+        // given
+        graduationRepository.save(graduation);
+
+        // when
+        Graduation findGraduation = graduationRepository.findByStudent(student)
+                .orElseThrow();
+
+        // then
+        assertAll(
+                () -> assertThat(findGraduation.getId()).isNotNull(),
+                () -> assertThat(findGraduation).isEqualTo(graduation)
+        );
+    }
+}

--- a/src/test/java/com/kyonggi/cspop/repository/GraduationRepositoryTest.java
+++ b/src/test/java/com/kyonggi/cspop/repository/GraduationRepositoryTest.java
@@ -22,7 +22,6 @@ class GraduationRepositoryTest extends RepositoryTest {
     @BeforeEach
     void setUp() {
         student = new Student(
-                1L,
                 "201811111",
                 "123",
                 "111&!a",
@@ -32,8 +31,7 @@ class GraduationRepositoryTest extends RepositoryTest {
                 PhoneNumber.from("010-1111-1111"),
                 "dummy",
                 Email.from("1@naver.com"),
-                Classification.UNDERGRADUATE_STUDENT,
-                RoleType.ADMIN
+                Classification.UNDERGRADUATE_STUDENT
         );
         graduation = new Graduation(
                 Method.THESIS,

--- a/src/test/java/com/kyonggi/cspop/repository/RepositoryTest.java
+++ b/src/test/java/com/kyonggi/cspop/repository/RepositoryTest.java
@@ -23,4 +23,7 @@ public abstract class RepositoryTest {
 
     @Autowired
     protected ScheduleBoardRepository scheduleBoardRepository;
+
+    @Autowired
+    protected GraduationRepository graduationRepository;
 }

--- a/src/test/java/com/kyonggi/cspop/service/ServiceTest.java
+++ b/src/test/java/com/kyonggi/cspop/service/ServiceTest.java
@@ -1,6 +1,7 @@
 package com.kyonggi.cspop.service;
 
 import com.kyonggi.cspop.repository.*;
+import com.kyonggi.cspop.service.graduate.SubmitService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,6 +27,9 @@ public abstract class ServiceTest {
     protected NoticeBoardService noticeBoardService;
 
     @Autowired
+    protected SubmitService submitService;
+
+    @Autowired
     protected StudentRepository studentRepository;
 
     @Autowired
@@ -42,6 +46,12 @@ public abstract class ServiceTest {
 
     @Autowired
     protected ScheduleBoardRepository scheduleBoardRepository;
+
+    @Autowired
+    protected GraduationRepository graduationRepository;
+
+    @Autowired
+    protected SubmitRepository submitRepository;
 
     @Autowired
     protected PasswordEncoder passwordEncoder;

--- a/src/test/java/com/kyonggi/cspop/service/ServiceTest.java
+++ b/src/test/java/com/kyonggi/cspop/service/ServiceTest.java
@@ -1,6 +1,7 @@
 package com.kyonggi.cspop.service;
 
 import com.kyonggi.cspop.repository.*;
+import com.kyonggi.cspop.service.graduate.ProposalService;
 import com.kyonggi.cspop.service.graduate.SubmitService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,6 +31,9 @@ public abstract class ServiceTest {
     protected SubmitService submitService;
 
     @Autowired
+    protected ProposalService proposalService;
+
+    @Autowired
     protected StudentRepository studentRepository;
 
     @Autowired
@@ -52,6 +56,9 @@ public abstract class ServiceTest {
 
     @Autowired
     protected SubmitRepository submitRepository;
+
+    @Autowired
+    protected ProposalRepository proposalRepository;
 
     @Autowired
     protected PasswordEncoder passwordEncoder;

--- a/src/test/java/com/kyonggi/cspop/service/ServiceTest.java
+++ b/src/test/java/com/kyonggi/cspop/service/ServiceTest.java
@@ -1,6 +1,7 @@
 package com.kyonggi.cspop.service;
 
 import com.kyonggi.cspop.repository.*;
+import com.kyonggi.cspop.service.graduate.MiddleService;
 import com.kyonggi.cspop.service.graduate.ProposalService;
 import com.kyonggi.cspop.service.graduate.SubmitService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +35,9 @@ public abstract class ServiceTest {
     protected ProposalService proposalService;
 
     @Autowired
+    protected MiddleService middleService;
+
+    @Autowired
     protected StudentRepository studentRepository;
 
     @Autowired
@@ -59,6 +63,9 @@ public abstract class ServiceTest {
 
     @Autowired
     protected ProposalRepository proposalRepository;
+
+    @Autowired
+    protected MiddleRepository middleRepository;
 
     @Autowired
     protected PasswordEncoder passwordEncoder;

--- a/src/test/java/com/kyonggi/cspop/service/graduate/MiddleServiceTest.java
+++ b/src/test/java/com/kyonggi/cspop/service/graduate/MiddleServiceTest.java
@@ -1,0 +1,120 @@
+package com.kyonggi.cspop.service.graduate;
+
+import com.kyonggi.cspop.domain.graduate.*;
+import com.kyonggi.cspop.domain.schedule.Step;
+import com.kyonggi.cspop.domain.student.*;
+import com.kyonggi.cspop.exception.NoSuchMiddleException;
+import com.kyonggi.cspop.exception.NoSuchProposalException;
+import com.kyonggi.cspop.exception.NoSuchStudentIdException;
+import com.kyonggi.cspop.service.ServiceTest;
+import com.kyonggi.cspop.service.dto.graduate.middle.MiddleSaveRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static java.time.LocalDate.now;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class MiddleServiceTest extends ServiceTest {
+
+    Student student;
+    Graduation graduation;
+
+    @BeforeEach
+    void setUp() {
+        student = new Student(
+                "201811111",
+                "123",
+                "111&!a",
+                now().minusDays(1),
+                Department.AI,
+                Grade.FIRTH,
+                PhoneNumber.from("010-1111-1111"),
+                "dummy",
+                Email.from("1@naver.com"),
+                Classification.UNDERGRADUATE_STUDENT
+        );
+        graduation = new Graduation(
+                Method.THESIS,
+                Status.UN_APPROVAL,
+                Step.RECEIVE,
+                false,
+                now().plusDays(1),
+                "professor",
+                student
+        );
+        studentRepository.save(student);
+        graduationRepository.save(graduation);
+    }
+
+    @Test
+    @DisplayName("회원가입하지 않은 학생이 중간 보고서를 제출하면 예외가 발생한다.")
+    void throwException_noSuchStudent() {
+        // given
+        MiddleSaveRequestDto middleSaveRequestDto = createMiddleSaveRequestDto();
+        Long invalidId = 999L;
+
+        // then
+        assertThatThrownBy(() -> middleService.saveMiddle(middleSaveRequestDto, invalidId))
+                .isInstanceOf(NoSuchStudentIdException.class)
+                .hasMessage(String.format("가입되지 않은 학생입니다. studentId={%d}", invalidId));
+    }
+
+    @Test
+    @DisplayName("중간 보고서를 신청하지 않은 학생을 승인하면 예외가 발생한다.")
+    void throwException_NoSuchMiddle() {
+        assertThatThrownBy(() -> middleService.approveMiddle(student.getId()))
+                .isInstanceOf(NoSuchMiddleException.class)
+                .hasMessage(String.format("중간보고서 제출을 하지 않은 학생입니다. id = {%d}", student.getId()));
+    }
+
+    @Test
+    @DisplayName("중간 보고서를 승인 상태로 수정한다.")
+    void updateApprove() {
+        // given
+        MiddleSaveRequestDto middleSaveRequestDto = createMiddleSaveRequestDto();
+        Long saveId = middleService.saveMiddle(middleSaveRequestDto, student.getId())
+                .getId();
+
+        // when
+        middleService.approveMiddle(student.getId());
+        Middle middle = middleRepository.findById(saveId)
+                .orElseThrow();
+
+        // then
+        assertAll(
+                () -> assertThat(graduation.getStep()).isEqualTo(Step.FINAL),
+                () -> assertThat(middle.getApprove()).isEqualTo(true)
+        );
+    }
+
+    @Test
+    @DisplayName("중간보고서의 승인을 거절한다.")
+    void rejectMiddle() {
+        // given
+        MiddleSaveRequestDto middleSaveRequestDto = createMiddleSaveRequestDto();
+        Long saveId = middleService.saveMiddle(middleSaveRequestDto, student.getId())
+                .getId();
+        String reason = "reason";
+
+        // when
+        middleService.rejectMiddle(student.getId(), reason);
+        Middle middle = middleRepository.findById(saveId)
+                .orElseThrow();
+
+        // then
+        assertThat(middle).extracting("approve", "reason")
+                .containsExactly(false, reason);
+    }
+
+    private MiddleSaveRequestDto createMiddleSaveRequestDto() {
+        return new MiddleSaveRequestDto(
+                "title",
+                Type.from("구현"),
+                "text",
+                "plan"
+        );
+    }
+}

--- a/src/test/java/com/kyonggi/cspop/service/graduate/ProposalServiceTest.java
+++ b/src/test/java/com/kyonggi/cspop/service/graduate/ProposalServiceTest.java
@@ -1,0 +1,120 @@
+package com.kyonggi.cspop.service.graduate;
+
+import com.kyonggi.cspop.domain.graduate.*;
+import com.kyonggi.cspop.domain.schedule.Step;
+import com.kyonggi.cspop.domain.student.*;
+import com.kyonggi.cspop.exception.NoSuchProposalException;
+import com.kyonggi.cspop.exception.NoSuchStudentIdException;
+import com.kyonggi.cspop.service.ServiceTest;
+import com.kyonggi.cspop.service.dto.graduate.proposal.ProposalSaveRequestDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static java.time.LocalDate.now;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProposalServiceTest extends ServiceTest {
+
+    Student student;
+    Graduation graduation;
+
+    @BeforeEach
+    void setUp() {
+        student = new Student(
+                "201811111",
+                "123",
+                "111&!a",
+                now().minusDays(1),
+                Department.AI,
+                Grade.FIRTH,
+                PhoneNumber.from("010-1111-1111"),
+                "dummy",
+                Email.from("1@naver.com"),
+                Classification.UNDERGRADUATE_STUDENT
+        );
+        graduation = new Graduation(
+                Method.THESIS,
+                Status.UN_APPROVAL,
+                Step.RECEIVE,
+                false,
+                now().plusDays(1),
+                "professor",
+                student
+        );
+        studentRepository.save(student);
+        graduationRepository.save(graduation);
+    }
+
+    @Test
+    @DisplayName("회원가입하지 않은 학생이 제안서를 제출하면 예외가 발생한다.")
+    void throwException_noSuchStudent() {
+        // given
+        ProposalSaveRequestDto proposalSaveRequestDto = createProposalSaveRequestDto();
+        Long invalidId = 999L;
+
+        // then
+        assertThatThrownBy(() -> proposalService.saveProposal(proposalSaveRequestDto, invalidId))
+                .isInstanceOf(NoSuchStudentIdException.class)
+                .hasMessage(String.format("가입되지 않은 학생입니다. studentId={%d}", invalidId));
+    }
+
+    @Test
+    @DisplayName("제안서를 신청하지 않은 학생을 승인하면 예외가 발생한다.")
+    void throwException_NoSuchProposal() {
+        assertThatThrownBy(() -> proposalService.approveProposal(student.getId()))
+                .isInstanceOf(NoSuchProposalException.class)
+                .hasMessage(String.format("제안서 제출을 하지 않은 학생입니다. id = {%d}", student.getId()));
+    }
+
+    @Test
+    @DisplayName("제안서를 승인 상태로 수정한다.")
+    void updateApprove() {
+        // given
+        ProposalSaveRequestDto proposalSaveRequestDto = createProposalSaveRequestDto();
+        Long saveId = proposalService.saveProposal(proposalSaveRequestDto, student.getId())
+                .getId();
+
+        // when
+        proposalService.approveProposal(student.getId());
+        Proposal proposal = proposalRepository.findById(saveId)
+                .orElseThrow();
+
+        // then
+        assertAll(
+                () -> assertThat(graduation.getStep()).isEqualTo(Step.MIDDLE),
+                () -> assertThat(proposal.getApprove()).isEqualTo(true)
+        );
+    }
+
+    @Test
+    @DisplayName("제안서의 승인을 거절한다.")
+    void rejectProposal() {
+        // given
+        ProposalSaveRequestDto proposalSaveRequestDto = createProposalSaveRequestDto();
+        Long saveId = proposalService.saveProposal(proposalSaveRequestDto, student.getId())
+                .getId();
+        String reason = "reason";
+
+        // when
+        proposalService.rejectProposal(student.getId(), reason);
+        Proposal proposal = proposalRepository.findById(saveId)
+                .orElseThrow();
+
+        // then
+        assertThat(proposal).extracting("approve", "reason")
+                .containsExactly(false, reason);
+    }
+
+    private ProposalSaveRequestDto createProposalSaveRequestDto() {
+        return new ProposalSaveRequestDto(
+                "title",
+                Type.from("구현"),
+                "qualification",
+                "content"
+        );
+    }
+}

--- a/src/test/java/com/kyonggi/cspop/service/graduate/SubmitServiceTest.java
+++ b/src/test/java/com/kyonggi/cspop/service/graduate/SubmitServiceTest.java
@@ -1,0 +1,126 @@
+package com.kyonggi.cspop.service.graduate;
+
+import com.kyonggi.cspop.domain.graduate.Graduation;
+import com.kyonggi.cspop.domain.graduate.Method;
+import com.kyonggi.cspop.domain.graduate.Status;
+import com.kyonggi.cspop.domain.graduate.Submit;
+import com.kyonggi.cspop.domain.schedule.Step;
+import com.kyonggi.cspop.domain.student.*;
+import com.kyonggi.cspop.exception.NoSuchStudentIdException;
+import com.kyonggi.cspop.exception.NoSuchSubmitException;
+import com.kyonggi.cspop.service.ServiceTest;
+import com.kyonggi.cspop.service.dto.graduate.submit.SubmitUpdateRequestDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static com.kyonggi.cspop.domain.schedule.Step.PROPOSAL;
+import static java.time.LocalDate.now;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SubmitServiceTest extends ServiceTest {
+
+    Student student;
+    Graduation graduation;
+
+    @BeforeEach
+    void setUp() {
+        student = new Student(
+                "201811111",
+                "123",
+                "111&!a",
+                now().minusDays(1),
+                Department.AI,
+                Grade.FIRTH,
+                PhoneNumber.from("010-1111-1111"),
+                "dummy",
+                Email.from("1@naver.com"),
+                Classification.UNDERGRADUATE_STUDENT
+        );
+        graduation = new Graduation(
+                Method.THESIS,
+                Status.UN_APPROVAL,
+                Step.RECEIVE,
+                false,
+                now().plusDays(1),
+                "professor",
+                student
+        );
+        studentRepository.save(student);
+        graduationRepository.save(graduation);
+    }
+
+    @Test
+    @DisplayName("회원가입을 하지 않은 학생이 졸업을 신청하면 예외가 발생한다.")
+    void throwException_noSuchStudent() {
+        assertThatThrownBy(() -> submitService.saveSubmit(999L))
+                .isInstanceOf(NoSuchStudentIdException.class)
+                .hasMessage(String.format("가입되지 않은 학생입니다. studentId={%d}", 999L));
+    }
+
+    @Test
+    @DisplayName("졸업 신청 접수를 하지 않은 학생을 승인하면 예외가 발생한다.")
+    void throwException_noSuchSubmit() {
+        // given
+        SubmitUpdateRequestDto submitUpdateRequestDto = new SubmitUpdateRequestDto(
+                now().plusDays(1),
+                false,
+                false,
+                "reason"
+        );
+
+        // then
+        assertThatThrownBy(() -> submitService.approveSubmit(submitUpdateRequestDto, student.getId()))
+                .isInstanceOf(NoSuchSubmitException.class)
+                .hasMessage(String.format("접수를 하지 않은 학생입니다. id = {%d}", student.getId()));
+    }
+
+    @Test
+    @DisplayName("신청을 접수한다.")
+    void saveSubmitAndFind() {
+        // given
+        Long saveId = submitService.saveSubmit(student.getId())
+                .getId();
+
+        // when
+        Submit submit = submitRepository.findById(saveId)
+                .orElseThrow();
+
+        // then
+        assertThat(submit).extracting("id", "name")
+                .containsExactly(saveId, student.getName());
+    }
+
+    @Test
+    @DisplayName("신청한 접수를 승인한다.")
+    void approveSubmit() {
+        // given
+        Long saveId = submitService.saveSubmit(student.getId())
+                .getId();
+
+        // when
+        SubmitUpdateRequestDto submitUpdateRequestDto = new SubmitUpdateRequestDto(
+                now().plusDays(1),
+                false,
+                false,
+                "reason"
+        );
+        submitService.approveSubmit(submitUpdateRequestDto, student.getId());
+        Submit submit = submitRepository.findById(saveId)
+                .orElseThrow();
+
+        // then
+        assertAll(
+                () -> assertThat(student.getGraduation()).extracting("step", "date", "professorName")
+                        .containsExactly(PROPOSAL, submitUpdateRequestDto.getGraduateDate(), student.getName()),
+                () -> assertThat(submit).extracting("graduateDate", "completion", "approve", "reason")
+                        .containsExactly(now().plusDays(1), false, false, "reason")
+        );
+    }
+}


### PR DESCRIPTION
## Overview
- 기존 학과 졸업 서비스의 잘못된 DB 설계와 연관 관계를 해결합니다.
![image](https://github.com/user-attachments/assets/3a3cf0c5-0dc5-44d6-a0b6-2865e44ebcb3)
졸업 신청자를 200명으로 가정하고 실험을 진행했습니다.

![image](https://github.com/user-attachments/assets/6da959b9-78d3-487a-9253-e68bfdd68b18)
기존 테이블 설계에서는 200 행의 졸업자 전체를 조회할 때, graduation 테이블 select all 1번과 apply 테이블 select Byid 200번이 발생하고 200번의 (신청 접수, 제안서, 중간 보고서, 최종 보고서 테이블 id) 조회로 인한 800개의 데이터 전송이 발생합니다.

- 지연로딩 적용
![image](https://github.com/user-attachments/assets/7a375f0d-d374-479b-b6ac-7989593dabf1)

```
적용 전 대비 73% 시간 감소, 지연로딩으로 인한 졸업자 단건 조회 시 발생하는 쿼리는 join fetch
```

- 테이블 재설계
![image](https://github.com/user-attachments/assets/0aeb3fa6-5de3-4ae9-b05e-160bd9940075)
기존 다대다 매핑을 1대1 관계로 수정하고, 불필요한 테이블을 제거했습니다.

## Change Log
- controller/
- domain/graduate/
- repository/
- service/graduate/
- test/


## Issue Tags
- closed: #10
